### PR TITLE
fix action scaler bug of predict_value method

### DIFF
--- a/d3rlpy/algos/torch/utility.py
+++ b/d3rlpy/algos/torch/utility.py
@@ -53,7 +53,7 @@ class DiscreteQFunctionMixin:
 
 class ContinuousQFunctionMixin:
     @eval_api
-    @torch_api(scaler_targets=["x"])
+    @torch_api(scaler_targets=["x"], action_scaler_targets=["action"])
     def predict_value(
         self: _ContinuousQFunctionProtocol,
         x: torch.Tensor,


### PR DESCRIPTION
added action_scaler_target to ContinuousQFunctionMixin's predict_value method

considerations:

- The fix looked scary because I found predict_value method being used in most of scorer functions
- Please let me know if I need to write any tests for this