### PR TITLE
Added options to save plots to file

### DIFF
--- a/d3rlpy/cli.py
+++ b/d3rlpy/cli.py
@@ -33,7 +33,7 @@ def get_plt() -> "matplotlib.pyplot":
     import matplotlib.pyplot as plt
 
     try:
-        # enable seaborn style if avaiable
+        # enable seaborn style if available
         import seaborn as sns
 
         sns.set()

--- a/d3rlpy/cli.py
+++ b/d3rlpy/cli.py
@@ -53,19 +53,6 @@ def stats(path: str) -> None:
     print_stats(path)
 
 
-def _plot_show_or_save(plt: "matplotlib.pyplot",
-                 png: str,
-                 pdf: str,
-) -> None:
-    if png or pdf:
-        if png:
-            plt.savefig(png+'.png', format='png')
-        if pdf:
-            plt.savefig(pdf+'.pdf', format='pdf')
-    else:
-        plt.show()
-
-
 @cli.command(short_help="Plot saved metrics (requires matplotlib).")
 @click.argument("path", nargs=-1)
 @click.option(
@@ -78,8 +65,9 @@ def _plot_show_or_save(plt: "matplotlib.pyplot",
 @click.option("--ylim", nargs=2, type=float, help="limit on y-axis (tuple).")
 @click.option("--title", help="title of the plot.")
 @click.option("--ylabel", default="value", help="label on y-axis.")
-@click.option("--png", default=None, nargs=1, help="save to named png file.")
-@click.option("--pdf", default=None, nargs=1, help="save to named pdf file.")
+@click.option(
+    "--save", default=None, nargs=1, help="save to named png or pdf file."
+)
 def plot(
     path: List[str],
     window: int,
@@ -90,8 +78,7 @@ def plot(
     ylim: Optional[Tuple[float, float]],
     title: Optional[str],
     ylabel: str,
-    png: str,
-    pdf: str,
+    save: str,
 ) -> None:
     plt = get_plt()
 
@@ -153,14 +140,20 @@ def plot(
         plt.title(title)
 
     plt.legend()
-    _plot_show_or_save(plt, png, pdf)
+    if save:
+        plt.savefig(save)
+    else:
+        plt.show()
+
 
 @cli.command(short_help="Plot saved metrics in a grid (requires matplotlib).")
 @click.argument("path")
 @click.option("--title", help="title of the plot.")
-@click.option("--png", default=None, nargs=1, help="save to named png file.")
-@click.option("--pdf", default=None, nargs=1, help="save to named pdf file.")
-def plot_all(path: str,
+@click.option(
+    "--save", default=None, nargs=1, help="save to named png or pdf file."
+)
+def plot_all(
+    path: str,
     title: Optional[str],
     png: str,
     pdf: str,
@@ -200,7 +193,11 @@ def plot_all(path: str,
         plt.suptitle(title)
 
     plt.tight_layout()
-    _plot_show_or_save(plt, png, pdf)
+    if save:
+        plt.savefig(save)
+    else:
+        plt.show()
+
 
 def _get_params_json_path(path: str) -> str:
     dirname = os.path.dirname(path)

--- a/d3rlpy/cli.py
+++ b/d3rlpy/cli.py
@@ -53,6 +53,19 @@ def stats(path: str) -> None:
     print_stats(path)
 
 
+def _plot_show_or_save(plt: "matplotlib.pyplot",
+                 png: str,
+                 pdf: str,
+) -> None:
+    if png or pdf:
+        if png:
+            plt.savefig(png+'.png', format='png')
+        if pdf:
+            plt.savefig(pdf+'.pdf', format='pdf')
+    else:
+        plt.show()
+
+
 @cli.command(short_help="Plot saved metrics (requires matplotlib).")
 @click.argument("path", nargs=-1)
 @click.option(
@@ -65,6 +78,8 @@ def stats(path: str) -> None:
 @click.option("--ylim", nargs=2, type=float, help="limit on y-axis (tuple).")
 @click.option("--title", help="title of the plot.")
 @click.option("--ylabel", default="value", help="label on y-axis.")
+@click.option("--png", default=None, nargs=1, help="save to named png file.")
+@click.option("--pdf", default=None, nargs=1, help="save to named pdf file.")
 def plot(
     path: List[str],
     window: int,
@@ -75,6 +90,8 @@ def plot(
     ylim: Optional[Tuple[float, float]],
     title: Optional[str],
     ylabel: str,
+    png: str,
+    pdf: str,
 ) -> None:
     plt = get_plt()
 
@@ -136,12 +153,18 @@ def plot(
         plt.title(title)
 
     plt.legend()
-    plt.show()
-
+    _plot_show_or_save(plt, png, pdf)
 
 @cli.command(short_help="Plot saved metrics in a grid (requires matplotlib).")
 @click.argument("path")
-def plot_all(path: str) -> None:
+@click.option("--title", help="title of the plot.")
+@click.option("--png", default=None, nargs=1, help="save to named png file.")
+@click.option("--pdf", default=None, nargs=1, help="save to named pdf file.")
+def plot_all(path: str,
+    title: Optional[str],
+    png: str,
+    pdf: str,
+) -> None:
     plt = get_plt()
 
     # print params.json
@@ -173,9 +196,11 @@ def plot_all(path: str) -> None:
             plt.xlabel("epoch")
             plt.ylabel("value")
 
-    plt.tight_layout()
-    plt.show()
+    if title:
+        plt.suptitle(title)
 
+    plt.tight_layout()
+    _plot_show_or_save(plt, png, pdf)
 
 def _get_params_json_path(path: str) -> str:
     dirname = os.path.dirname(path)

--- a/d3rlpy/cli.py
+++ b/d3rlpy/cli.py
@@ -65,9 +65,7 @@ def stats(path: str) -> None:
 @click.option("--ylim", nargs=2, type=float, help="limit on y-axis (tuple).")
 @click.option("--title", help="title of the plot.")
 @click.option("--ylabel", default="value", help="label on y-axis.")
-@click.option(
-    "--save", default=None, nargs=1, help="save to named png or pdf file."
-)
+@click.option("--save", help="flag to save the plot as an image.")
 def plot(
     path: List[str],
     window: int,
@@ -149,9 +147,7 @@ def plot(
 @cli.command(short_help="Plot saved metrics in a grid (requires matplotlib).")
 @click.argument("path")
 @click.option("--title", help="title of the plot.")
-@click.option(
-    "--save", default=None, nargs=1, help="save to named png or pdf file."
-)
+@click.option("--save", help="flag to save the plot as an image.")
 def plot_all(
     path: str,
     title: Optional[str],

--- a/d3rlpy/cli.py
+++ b/d3rlpy/cli.py
@@ -155,8 +155,7 @@ def plot(
 def plot_all(
     path: str,
     title: Optional[str],
-    png: str,
-    pdf: str,
+    save: str,
 ) -> None:
     plt = get_plt()
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -29,6 +29,8 @@ Plot the saved metrics by specifying paths::
      - limit on y-axis (tuple).
    * - ``--title``
      - title of the plot.
+   * - ``--save``
+     - flag to save the plot as an image.
 
 example::
 


### PR DESCRIPTION
I added additional options to `d3rlpy plot` that allow one to save the plot to a named file

For example
```
d3rlpy plot --png plot1 --pdf plot2 d3rlpy_logs/actor_loss.csv
```
saves the plot to

```
plot1.png
plot2.pdf
```
I also allowed `--title` to be used with `d3rlpy plot-all`

For example
```
d3rlpy plot-all --title SupTitle d3rlpy_logs
```
puts a suptitle over all the subfigures.