### PR TITLE
update document to fit the fit_online api

### DIFF
--- a/docs/references/online.rst
+++ b/docs/references/online.rst
@@ -43,7 +43,7 @@ enough to be trained in an online manner with a few more utilities.
                    eval_env=eval_env,
                    n_steps=30000, # the number of total steps to train.
                    n_steps_per_epoch=1000,
-                   update_interval=10) # the number of total steps to train.
+                   update_interval=10) # update parameters every 10 steps.
 
 
 Replay Buffer

--- a/docs/references/online.rst
+++ b/docs/references/online.rst
@@ -41,9 +41,9 @@ enough to be trained in an online manner with a few more utilities.
                    buffer,
                    explorer=explorer, # you don't need this with probablistic policy algorithms
                    eval_env=eval_env,
-                   n_epochs=30,
+                   n_steps=30000, # the number of total steps to train.
                    n_steps_per_epoch=1000,
-                   n_updates_per_epoch=100)
+                   update_interval=10) # the number of total steps to train.
 
 
 Replay Buffer


### PR DESCRIPTION
in the latest api of fit_online (https://d3rlpy.readthedocs.io/en/v0.91/references/generated/d3rlpy.algos.CQL.html?highlight=fit_online#d3rlpy.algos.CQL.fit_online), n_epochs is changed to n_steps and n_updates_per_epoch is changed to update_interval.
I simply updated the document