### PR TITLE
Fixed typo in tutorial document

### DIFF
--- a/docs/tutorials/create_your_dataset.rst
+++ b/docs/tutorials/create_your_dataset.rst
@@ -66,7 +66,7 @@ In this case, you can use ``episode_terminals`` to represent this timeout states
   # timeout states
   episode_terminals = np.random.randint(2, size=1000)
 
-  dataset = d3rlpy.dataest.MDPDataset(
+  dataset = d3rlpy.dataset.MDPDataset(
       observations=observations,
       actions=actions,
       rewards=rewards,


### PR DESCRIPTION
Create Your Dataset section had some syntax errors due that I was able to fix with this minor change.