### PR TITLE
Update to use RecordVideo instead of deprecated Monitor class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ docs/references/generated
 coverage.xml
 .coverage
 .mypy_cache
+.ipynb_checkpoints
 build
 dist
 /.idea/

--- a/tutorials/cartpole.ipynb
+++ b/tutorials/cartpole.ipynb
@@ -14,6 +14,7 @@
    "outputs": [],
    "source": [
     "!pip install gym pyvirtualdisplay > /dev/null 2>&1\n",
+    "!pip install gym[classic_control] > /dev/null 2>&1\n",
     "!apt-get install -y xvfb python-opengl ffmpeg > /dev/null 2>&1"
    ]
   },
@@ -107,7 +108,7 @@
     "import io\n",
     "import base64\n",
     "\n",
-    "from gym.wrappers import Monitor\n",
+    "from gym.wrappers import RecordVideo\n",
     "from IPython.display import HTML\n",
     "from IPython import display as ipythondisplay\n",
     "from pyvirtualdisplay import Display\n",
@@ -144,8 +145,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# wrap Monitor wrapper\n",
-    "env = Monitor(env, './video', force=True)\n",
+    "# wrap RecordVideo wrapper\n",
+    "env = RecordVideo(env, './video')\n",
     "\n",
     "# evaluate\n",
     "evaluate_on_environment(env)(cql)"


### PR DESCRIPTION
@takuseno  Thanks for making this project. It makes installation easy and it's awesome.

As I tried the colab, I found the Monitor class is depricated in newer gym version. So I made these changes to keep it up to date.