### PR TITLE
Added explicit tracking cql regulariser value for DiscreteCQL

### DIFF
--- a/d3rlpy/algos/cql.py
+++ b/d3rlpy/algos/cql.py
@@ -371,3 +371,12 @@ class DiscreteCQL(DoubleDQN):
             reward_scaler=self._reward_scaler,
         )
         self._impl.build()
+
+    def _update(self, batch: TransitionMiniBatch) -> Dict[str, float]:
+        assert self._impl is not None, IMPL_NOT_INITIALIZED_ERROR
+        update_res = self._impl.update(batch)
+        loss = update_res[0]
+        cql_reg = update_res[1]
+        if self._grad_step % self._target_update_interval == 0:
+            self._impl.update_target()
+        return {"loss": loss, "cql_reg": cql_reg}

--- a/d3rlpy/algos/torch/cql_impl.py
+++ b/d3rlpy/algos/torch/cql_impl.py
@@ -301,7 +301,7 @@ class DiscreteCQLImpl(DoubleDQNImpl):
         return (logsumexp - data_values).mean()
 
     @train_api
-    @torch_api(scaler_targets=["obs_t", "obs_tpn"])
+    @torch_api()
     def update(self, batch: TorchMiniBatch) -> np.ndarray:
         assert self._optim is not None
 

--- a/d3rlpy/algos/torch/cql_impl.py
+++ b/d3rlpy/algos/torch/cql_impl.py
@@ -19,7 +19,6 @@ from .sac_impl import SACImpl
 
 
 class CQLImpl(SACImpl):
-
     _alpha_learning_rate: float
     _alpha_optim_factory: OptimizerFactory
     _initial_alpha: float
@@ -285,7 +284,7 @@ class DiscreteCQLImpl(DoubleDQNImpl):
         conservative_loss = self._compute_conservative_loss(
             batch.observations, batch.actions.long()
         )
-        return loss + self._alpha * conservative_loss
+        return loss + self._alpha * conservative_loss, conservative_loss
 
     def _compute_conservative_loss(
         self, obs_t: torch.Tensor, act_t: torch.Tensor
@@ -300,3 +299,22 @@ class DiscreteCQLImpl(DoubleDQNImpl):
         data_values = (self._q_func(obs_t) * one_hot).sum(dim=1, keepdim=True)
 
         return (logsumexp - data_values).mean()
+
+    @train_api
+    @torch_api(scaler_targets=["obs_t", "obs_tpn"])
+    def update(self, batch: TorchMiniBatch) -> np.ndarray:
+        assert self._optim is not None
+
+        self._optim.zero_grad()
+
+        q_tpn = self.compute_target(batch)
+
+        loss, cql_loss = self.compute_loss(batch, q_tpn)
+
+        loss.backward()
+        self._optim.step()
+
+        res = np.array(
+            [loss.cpu().detach().numpy(), cql_loss.cpu().detach().numpy()]
+        )
+        return res


### PR DESCRIPTION
Implemented by: 
- Method overriding the _update method of the d3rlpy/algos/dqn.py DQN class to handle the fact that the cql regulariser value is returned as well as the full loss
- Updating the d3rlpy/algos/torch/cql_impl.py DiscreteCQLImpl.compute_loss to return the full loss and conservative loss
- Method overriding the update method of the d3rlpy/algos/dqn.py DQN class to handle the fact that the cql regulariser value is also returned and outputted result in numpy array