### PR TITLE
Update datasets.py (Pendulum-v0 --> Pendulum-v1)

### DIFF
--- a/d3rlpy/datasets.py
+++ b/d3rlpy/datasets.py
@@ -94,7 +94,7 @@ def get_pendulum(dataset_type: str = "replay") -> Tuple[MDPDataset, gym.Env]:
     dataset = MDPDataset.load(data_path)
 
     # environment
-    env = gym.make("Pendulum-v0")
+    env = gym.make("Pendulum-v1")
 
     return dataset, env
 


### PR DESCRIPTION
I changed the version of Pendulum env from v0 to v1, as the current gym.make("Pendulum-v0") function no longer in support and throws the following error log:  
~~~python
DeprecatedEnv: Environment version v0 for `Pendulum` is deprecated. Please use `Pendulum-v1` instead.
~~~