### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
       libxrender1 \
       libpcre3-dev && \
     pip install --no-cache-dir \
-      Cython \
+      Cython==0.29.28 \
       git+https://github.com/takuseno/d4rl-atari && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \


### PR DESCRIPTION
By default this dockerfile is installing cython==3.0.0 version which gives error while installing the repo. At least version 1.1.1. See issue https://github.com/takuseno/d3rlpy/issues/310