### PR TITLE
Update finetuning.rst

### DIFF
--- a/docs/tutorials/finetuning.rst
+++ b/docs/tutorials/finetuning.rst
@@ -76,6 +76,7 @@ algorithms, you can do it in an out-of-the-box way.
 
   # transfer to DQN
   dqn = d3rlpy.algos.DQN()
+  dqn.build_with_env(env)
   dqn.copy_q_function_from(cql)
 
   # start finetuning


### PR DESCRIPTION
Calling the copy_q_function without building the algorithms, we skipped the network param init() call and throws of this error 

~~~python
AssertionError: The neural network parameters are not initialized. Pleaes call build_with_dataset, build_with_env, or directly call fit or fit_online method. ~~~