### PR TITLE
Record gradients every epoch

### DIFF
--- a/d3rlpy/algos/transformer/base.py
+++ b/d3rlpy/algos/transformer/base.py
@@ -418,15 +418,6 @@ class TransformerAlgoBase(
         # initialize scalers
         build_scalers_with_trajectory_slicer(self, dataset)
 
-        # setup logger
-        if experiment_name is None:
-            experiment_name = self.__class__.__name__
-        logger = D3RLPyLogger(
-            adapter_factory=logger_adapter,
-            experiment_name=experiment_name,
-            with_timestamp=with_timestamp,
-        )
-
         # instantiate implementation
         if self._impl is None:
             LOG.debug("Building models...")
@@ -440,6 +431,17 @@ class TransformerAlgoBase(
             LOG.debug("Models have been built.")
         else:
             LOG.warning("Skip building models since they're already built.")
+
+        # setup logger
+        if experiment_name is None:
+            experiment_name = self.__class__.__name__
+        logger = D3RLPyLogger(
+            algo=self,
+            adapter_factory=logger_adapter,
+            experiment_name=experiment_name,
+            n_steps_per_epoch=n_steps_per_epoch,
+            with_timestamp=with_timestamp,
+        )
 
         # save hyperparameters
         save_config(self, logger)

--- a/d3rlpy/logging/noop_adapter.py
+++ b/d3rlpy/logging/noop_adapter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from .logger import (
     AlgProtocol,
@@ -41,8 +41,6 @@ class NoopAdapter(LoggerAdapter):
         self,
         epoch: int,
         step: int,
-        logging_steps: Optional[int],
-        algo: AlgProtocol,
     ) -> None:
         pass
 
@@ -53,5 +51,7 @@ class NoopAdapterFactory(LoggerAdapterFactory):
     This class instantiates ``NoopAdapter`` object.
     """
 
-    def create(self, experiment_name: str) -> NoopAdapter:
+    def create(
+        self, algo: AlgProtocol, experiment_name: str, n_steps_per_epoch: int
+    ) -> NoopAdapter:
         return NoopAdapter()

--- a/d3rlpy/logging/tensorboard_adapter.py
+++ b/d3rlpy/logging/tensorboard_adapter.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import numpy as np
 
@@ -27,16 +27,18 @@ class TensorboardAdapter(LoggerAdapter):
         experiment_name (str): Experiment name.
     """
 
+    _algo: AlgProtocol
     _experiment_name: str
     _params: Dict[str, Any]
     _metrics: Dict[str, float]
 
-    def __init__(self, root_dir: str, experiment_name: str):
+    def __init__(self, algo: AlgProtocol, root_dir: str, experiment_name: str):
         try:
             from tensorboardX import SummaryWriter
         except ImportError as e:
             raise ImportError("Please install tensorboardX") from e
 
+        self._algo = algo
         self._experiment_name = experiment_name
         logdir = os.path.join(root_dir, "runs", experiment_name)
         self._writer = SummaryWriter(logdir=logdir)
@@ -73,15 +75,10 @@ class TensorboardAdapter(LoggerAdapter):
         self,
         epoch: int,
         step: int,
-        logging_steps: Optional[int],
-        algo: AlgProtocol,
     ) -> None:
-        assert algo.impl
-        if logging_steps is not None and step % logging_steps == 0:
-            for name, grad in algo.impl.modules.get_gradients():
-                self._writer.add_histogram(
-                    f"histograms/{name}_grad", grad, epoch
-                )
+        assert self._algo.impl
+        for name, grad in self._algo.impl.modules.get_gradients():
+            self._writer.add_histogram(f"histograms/{name}_grad", grad, epoch)
 
 
 class TensorboardAdapterFactory(LoggerAdapterFactory):
@@ -98,5 +95,7 @@ class TensorboardAdapterFactory(LoggerAdapterFactory):
     def __init__(self, root_dir: str = "tensorboard_logs"):
         self._root_dir = root_dir
 
-    def create(self, experiment_name: str) -> TensorboardAdapter:
-        return TensorboardAdapter(self._root_dir, experiment_name)
+    def create(
+        self, algo: AlgProtocol, experiment_name: str, n_steps_per_epoch: int
+    ) -> TensorboardAdapter:
+        return TensorboardAdapter(algo, self._root_dir, experiment_name)

--- a/d3rlpy/logging/utils.py
+++ b/d3rlpy/logging/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Sequence
 
 from .logger import (
     AlgProtocol,
@@ -53,11 +53,9 @@ class CombineAdapter(LoggerAdapter):
         self,
         epoch: int,
         step: int,
-        logging_steps: Optional[int],
-        algo: AlgProtocol,
     ) -> None:
         for adapter in self._adapters:
-            adapter.watch_model(epoch, step, logging_steps, algo)
+            adapter.watch_model(epoch, step)
 
 
 class CombineAdapterFactory(LoggerAdapterFactory):
@@ -75,10 +73,12 @@ class CombineAdapterFactory(LoggerAdapterFactory):
     def __init__(self, adapter_factories: Sequence[LoggerAdapterFactory]):
         self._adapter_factories = adapter_factories
 
-    def create(self, experiment_name: str) -> CombineAdapter:
+    def create(
+        self, algo: AlgProtocol, experiment_name: str, n_steps_per_epoch: int
+    ) -> CombineAdapter:
         return CombineAdapter(
             [
-                factory.create(experiment_name)
+                factory.create(algo, experiment_name, n_steps_per_epoch)
                 for factory in self._adapter_factories
             ]
         )

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -60,7 +60,12 @@ def from_json_tester(
     algo.create_impl(observation_shape, action_size)
     # save params.json
     adapter_factory = FileAdapterFactory("test_data")
-    logger = D3RLPyLogger(adapter_factory, experiment_name="test")
+    logger = D3RLPyLogger(
+        algo=algo,
+        adapter_factory=adapter_factory,
+        n_steps_per_epoch=1,
+        experiment_name="test",
+    )
     # save parameters to test_data/test/params.json
     save_config(algo, logger)
     # load params.json


### PR DESCRIPTION
@hasan-yaman Hi, I really like the new feature you added. Now, I'd like to push this forward to make it a default metric. In this PR, I dropped `gradient_logging_steps`. Instead, the logger saves the metrics every epoch. Does this still work for your use case?