### PR TITLE
Fix model loading with OptimizerWrapper

### DIFF
--- a/d3rlpy/optimizers/optimizers.py
+++ b/d3rlpy/optimizers/optimizers.py
@@ -5,6 +5,7 @@ from torch import nn
 from torch.optim import SGD, Adam, AdamW, Optimizer, RMSprop
 from torch.optim.lr_scheduler import LRScheduler
 
+from ..logging import LOG
 from ..serializable_config import DynamicConfig, generate_config_registration
 from .lr_schedulers import LRSchedulerFactory, make_lr_scheduler_field
 
@@ -102,9 +103,15 @@ class OptimizerWrapper:
         }
 
     def load_state_dict(self, state_dict: Mapping[str, Any]) -> None:
-        self._optim.load_state_dict(state_dict["optim"])
+        if "optim" in state_dict:
+            self._optim.load_state_dict(state_dict["optim"])
+        else:
+            LOG.warning("Skip loading optimizer state.")
         if self._lr_scheduler:
-            self._lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
+            if "lr_scheduler" in state_dict:
+                self._lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
+            else:
+                LOG.warning("Skip loading lr scheduler state.")
 
 
 @dataclasses.dataclass()


### PR DESCRIPTION
Problem:

- 1f2a9dc8ec95a8b295b68497ea290cc00c362b05 tries to load optimizer and LR scheduler. With this change model saved on the previous versions cannot be loaded with the latest version.

Minimum reproducible example:
```python
# git checkout bb984031fef4a9cc92a321aa8ceae3c0bbb64419
from d3rlpy.algos import DiscreteBCConfig
from d3rlpy.datasets import get_cartpole

dataset, _ = get_cartpole()

model = DiscreteBCConfig().create()

model.fit(
    dataset=dataset,
    n_steps_per_epoch=100,
    n_steps=300
)

model.save("bc.d3")
```

then try to load model

```python
# git checkout 1f2a9dc8ec95a8b295b68497ea290cc00c362b05
# or to the latest commit git checkout 5400c22d812b2dab9ae66b2def28e5b135c354fd
from d3rlpy import load_learnable

model = load_learnable("bc.d3")

```

It throws `KeyError: 'optim'`
