### PR TITLE
Episode termination precedence when both terminal and timeout flags are set

### DIFF
--- a/d3rlpy/dataset/episode_generator.py
+++ b/d3rlpy/dataset/episode_generator.py
@@ -58,9 +58,9 @@ class EpisodeGenerator(EpisodeGeneratorProtocol):
         if timeouts is None:
             timeouts = np.zeros_like(terminals)
 
-        assert (
-            np.sum(np.logical_and(terminals, timeouts)) == 0
-        ), "terminals and timeouts never become True at the same time"
+        if np.sum(np.logical_and(terminals, timeouts)) != 0:
+            # In case of overlap, 'terminal' is the important end condition
+            timeouts[terminals.astype(np.bool_)] = 0.0
         assert (np.sum(terminals) + np.sum(timeouts)) > 0, (
             "No episode termination was found. Either terminals"
             " or timeouts must include non-zero values."

--- a/reproductions/offline/qdt.py
+++ b/reproductions/offline/qdt.py
@@ -120,8 +120,9 @@ def relabel_dataset_rtg(
                 sampled_actions = q_algo.sample_action(episode.observations)
                 v = q_algo.predict_value(episode.observations, sampled_actions)
                 values.append(
-                    v if q_algo.reward_scaler is None 
-                          else q_algo.reward_scaler.reverse_transform(v)
+                    v
+                    if q_algo.reward_scaler is None
+                    else q_algo.reward_scaler.reverse_transform(v)
                 )
             value = np.array(values).mean(axis=0)
             rewards = np.squeeze(episode.rewards, axis=1)

--- a/tests/dataset/test_episode_generator.py
+++ b/tests/dataset/test_episode_generator.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -10,9 +12,14 @@ from ..testing_utils import create_observations
 @pytest.mark.parametrize("observation_shape", [(4,), ((4,), (8,))])
 @pytest.mark.parametrize("action_size", [2])
 @pytest.mark.parametrize("length", [1000])
-@pytest.mark.parametrize("terminal", [False, True])
+@pytest.mark.parametrize(
+    "episode_end_type", ["terminal", "truncated", "overlap"]
+)
 def test_episode_generator(
-    observation_shape: Shape, action_size: int, length: int, terminal: bool
+    observation_shape: Shape,
+    action_size: int,
+    length: int,
+    episode_end_type: str,
 ) -> None:
     observations = create_observations(observation_shape, length)
     actions = np.random.random((length, action_size))
@@ -20,9 +27,12 @@ def test_episode_generator(
     terminals: Float32NDArray = np.zeros(length, dtype=np.float32)
     timeouts: Float32NDArray = np.zeros(length, dtype=np.float32)
     for i in range(length // 100):
-        if terminal:
+        if episode_end_type == "terminal":
             terminals[(i + 1) * 100 - 1] = 1.0
+            terminal = True
         else:
+            terminal = False
+        if episode_end_type == "truncated" or episode_end_type == "overlap":
             timeouts[(i + 1) * 100 - 1] = 1.0
 
     episode_generator = EpisodeGenerator(
@@ -48,3 +58,25 @@ def test_episode_generator(
         assert episode.actions.shape == (100, action_size)
         assert episode.rewards.shape == (100, 1)
         assert episode.terminated == terminal
+
+
+def test_episode_generator_raises_on_no_termination() -> None:
+    observations = create_observations((4,), 100)
+    actions = np.zeros((100, 2))
+    rewards: Float32NDArray = np.zeros((100, 1), dtype=np.float32)
+    terminals = np.zeros(100, dtype=np.float32)
+    timeouts = np.zeros(100, dtype=np.float32)
+
+    expected_msg = (
+        "No episode termination was found. "
+        "Either terminals or timeouts must include non-zero values."
+    )
+
+    with pytest.raises(AssertionError, match=re.escape(expected_msg)):
+        EpisodeGenerator(
+            observations=observations,
+            actions=actions,
+            rewards=rewards,
+            terminals=terminals,
+            timeouts=timeouts,
+        )


### PR DESCRIPTION
Currently, when generating episode data with `EpisodeGenerator`, an assertion error
```
terminals and timeouts never become True at the same time
```
is raised if an episode terminates in the same timestep at which truncation occurs.

However, it is possible for an environment to terminate in the same timestep in which the [`TimeLimit`](https://github.com/Farama-Foundation/Gymnasium/blob/7cb208f491fd9876a8ee41bb2d8d212d0d6ffabc/gymnasium/wrappers/common.py#L125C1-L131C64) wrapper truncates an episode. In this case, the environment’s `step` method (see, e.g., [Humanoid-v5](https://github.com/Farama-Foundation/Gymnasium/blob/7cb208f491fd9876a8ee41bb2d8d212d0d6ffabc/gymnasium/envs/mujoco/humanoid_v5.py#L473C1-L498C60)) has already returned a termination signal, which the `TimeLimit` wrapper simply passes through while adding its truncation flag. As a result, both termination and truncation can be `True` in the same timestep.

To handle this overlap, I suggest giving precedence to termination. The rationale is:

- Termination is the primary end condition: if the environment signals termination, truncation is redundant.
- Treating the final step as a termination (rather than truncation) makes that last transition usable for learning, adding one more usable timestep.

Concretely, the assertion

```python
assert (
    np.sum(np.logical_and(terminals, timeouts)) == 0
), "terminals and timeouts never become True at the same time"
 ```
 
is replaced with:
 
 ```python
 if np.sum(np.logical_and(terminals, timeouts)) != 0:
    timeouts[terminals.astype(np.bool_)] = 0.0
 ```

While the practical effect of this change is limited — since the [`TransitionPicker`](https://github.com/takuseno/d3rlpy/blob/4f0956ba8db469ebeeb617bb28060a8401a7dfa6/d3rlpy/dataset/transition_pickers.py#L50C1-L50C40) discards the final timestep of each episode — it prevents assertion failures when constructing datasets from trajectories that contain termination–truncation overlaps.

---

Another option would be to remove

```python
assert (
    np.sum(np.logical_and(terminals, timeouts)) == 0
), "terminals and timeouts never become True at the same time"
```

This way, timeout information stays in the `_timeouts` attribute of the `EpisodeGenerator`, keeping it consistent with the environment’s return values, but deviating from the implied intention of the assertion if it was meant to be more than just a consistency check.
